### PR TITLE
Specify main class, class path, and include dependencies when building jar

### DIFF
--- a/refresh-cwlib-worker/pom.xml
+++ b/refresh-cwlib-worker/pom.xml
@@ -54,4 +54,39 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>refresh.workers.cwlib.Main</mainClass>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>lib/</classpathPrefix>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.8</version>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/refresh-cwlib-worker/pom.xml
+++ b/refresh-cwlib-worker/pom.xml
@@ -70,6 +70,8 @@
                     </archive>
                 </configuration>
             </plugin>
+
+            <!-- source: https://stackoverflow.com/a/32368955 -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>


### PR DESCRIPTION
This fixes two bugs which previously, for me atleast, prevented java from properly executing the worker jar after building it using the maven CLI:
- The jar's manifest will now specify the main class so that java could find it
- The manifest will now also specify a class path (which java will use to find the dependency jars), and in a way where java will search for these dependencies in the `/lib` subdirectory. Additionally, maven will now be instructed to deploy these dependencies into `/lib` when building the worker, so that java could find them on runtime, preventing it from throwing `NoClassDefFoundError`.